### PR TITLE
add redis 支持密码连接，支持选择仓库。

### DIFF
--- a/src/Cache/Redis/RedisConnect.php
+++ b/src/Cache/Redis/RedisConnect.php
@@ -31,14 +31,21 @@ class RedisConnect extends AbstractConnect
         // 连接信息
         $timeout = $this->connectPool->getTimeout();
         $address = $this->connectPool->getConnectAddress();
-        list($host, $port) = explode(":", $address);
+        $config = $this->parseUri($address);
 
         // 创建连接
         $redis = new Redis();
-        $result = $redis->connect($host, $port, $timeout);
+        $result = $redis->connect($config['host'], $config['port'], $timeout);
         if ($result == false) {
-            App::error("redis连接失败，host=" . $host . " port=" . $port . " timeout=" . $timeout);
+            App::error("redis 连接失败，host=" . $config['host'] . " port=" . $config['port'] . " timeout=" . $timeout);
             return;
+        }
+        if(isset($config['auth']) && false === $redis->auth($config['auth'])){
+            App::error("redis 连接认证失败，host=" . $config['host'] . " port=" . $config['port'] . " timeout=" . $timeout);
+            return;
+        }
+        if(isset($config['database']) && $config['database'] < 16 && false === $redis->select($config['database'])){
+            App::warning("redis 连接选择仓库失败，host=" . $config['host'] . " port=" . $config['port'] . " timeout=" . $timeout);
         }
 
         $this->connect = $redis;
@@ -60,6 +67,28 @@ class RedisConnect extends AbstractConnect
     public function setDefer($defer = true)
     {
         $this->connect->setDefer($defer);
+    }
+
+    /**
+     * 解析 uri 连接串
+     *
+     * @param string $uri 参考 : `tcp://127.0.0.1:6379/1?auth=deepziyu`
+     *
+     * @return array
+     */
+    protected function parseUri(string $uri)
+    {
+        $parseAry = parse_url($uri);
+        if (!isset($parseAry['host']) || !isset($parseAry['port'])) {
+            throw new \InvalidArgumentException("redis 连接 uri 格式不正确，uri= ,请参考:tcp://127.0.0.1:6379/1?auth=deepziyu" . $uri);
+        }
+        isset($parseAry['path']) && $parseAry['database'] = str_replace('/', '', $parseAry['path']);
+        $query = $parseAry['query'];
+        parse_str($query, $options);
+        $configs = array_merge($parseAry, $options);
+        unset($configs['path']);
+        unset($configs['query']);
+        return $configs;
     }
 
     /**

--- a/src/Cache/Redis/RedisConnect.php
+++ b/src/Cache/Redis/RedisConnect.php
@@ -72,7 +72,7 @@ class RedisConnect extends AbstractConnect
     /**
      * 解析 uri 连接串
      *
-     * @param string $uri 参考 : `tcp://127.0.0.1:6379/1?auth=deepziyu`
+     * @param string $uri 参考 : `tcp://127.0.0.1:6379/1?auth=password`
      *
      * @return array
      */
@@ -80,7 +80,7 @@ class RedisConnect extends AbstractConnect
     {
         $parseAry = parse_url($uri);
         if (!isset($parseAry['host']) || !isset($parseAry['port'])) {
-            throw new \InvalidArgumentException("redis 连接 uri 格式不正确，uri= ,请参考:tcp://127.0.0.1:6379/1?auth=deepziyu" . $uri);
+            throw new \InvalidArgumentException("redis 连接 uri 格式不正确，uri= ,请参考:tcp://127.0.0.1:6379/1?auth=password" . $uri);
         }
         isset($parseAry['path']) && $parseAry['database'] = str_replace('/', '', $parseAry['path']);
         $query = $parseAry['query'];


### PR DESCRIPTION
change 不兼容旧的 uri 写法。
参考写法：
"redisPool" => [
    "uri"             => [
		'tcp://127.0.0.3:6379',
		'tcp://127.0.0.2:6379/13',
        'tcp://127.0.0.1:6379/1?auth=deepziyu' // path 部分为选择的仓库，auth 参数为密码
    ],
]