### PR TITLE
add check for openswoole ext name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "truffle/framework",
+  "name": "swoft/framework",
   "type": "library",
   "version": "v2.0.11",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "swoft/framework",
   "type": "library",
-  "version": "v2.0.11",
+  "version": "v2.0.12",
   "keywords": [
     "php",
     "swoole",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "swoft/framework",
+  "name": "truffle/framework",
   "type": "library",
   "version": "v2.0.11",
   "keywords": [

--- a/src/Helper/SwoftHelper.php
+++ b/src/Helper/SwoftHelper.php
@@ -52,7 +52,7 @@ class SwoftHelper
             throw new RuntimeException('Run the server requires PHP version > ' . $minPhp . '! current is ' . PHP_VERSION);
         }
 
-        if (!extension_loaded('swoole')) {
+        if (!extension_loaded('openswoole') && !extension_loaded('swoole')) {
             throw new RuntimeException("Run the server, extension 'swoole' is required!");
         }
 


### PR DESCRIPTION
Notice: ext-swoole is supported until v4.7.1, use ext-openswoole >= v4.7.1. Latest version: pecl install openswoole-4.9.0

https://www.swoole.co.uk/